### PR TITLE
Fixed ravenscar-sfp-rm46 runtime project file.

### DIFF
--- a/ravenscar-sfp-rm46/runtime_build.gpr
+++ b/ravenscar-sfp-rm46/runtime_build.gpr
@@ -8,7 +8,7 @@ project Runtime_Build is
   for Library_Dir use "adalib";
   for Object_Dir use "obj";
 
-  for Source_Dirs use ("arch", "common", "math");
+  for Source_Dirs use ("arch", "common");
 
   type Build_Type is ("Production", "Debug");
 


### PR DESCRIPTION
Deleted "math" from Source_Dirs list. Directory math is no included in the ravenscar-sfp-rm46 directory and the runtime project wouldn't build.
